### PR TITLE
Fix: JWT Payload validation for 2FA Strategy

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -159,7 +159,9 @@ describe('AuthService', () => {
 
   it('should verify the JWT payload', async () => {
     const payload: JwtPayload = {
-      sub: 'john@doe.me',
+      sub: 'notregistered@example.com',
+      email: 'notregistered@example.com',
+      isTwoFactorAuthenticationEnabled: false,
       iat: 0,
       exp: 0
     }
@@ -176,6 +178,8 @@ describe('AuthService', () => {
   it("should throw on verify when JWT's subject not exist", async () => {
     const payload: JwtPayload = {
       sub: 'notregistered@example.com',
+      email: 'notregistered@example.com',
+      isTwoFactorAuthenticationEnabled: false,
       iat: 0,
       exp: 0
     }

--- a/apps/api/src/auth/strategies/jwt-2fa.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt-2fa.strategy.ts
@@ -14,6 +14,6 @@ export class Jwt2faStrategy extends PassportStrategy(Strategy, 'jwt-2fa') {
   }
 
   async validate(payload: JwtPayload) {
-    return this.authService.verifyPayload(payload);
+    return this.authService.verifyPayload(payload)
   }
 }

--- a/apps/api/src/auth/strategies/jwt-2fa.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt-2fa.strategy.ts
@@ -1,32 +1,19 @@
 import { ExtractJwt, Strategy } from 'passport-jwt'
 import { PassportStrategy } from '@nestjs/passport'
 import { Injectable } from '@nestjs/common'
-import { UserService } from '../../user/user.service'
-import { LoginWith2FAPayload } from '@isomera/interfaces'
+import { JwtPayload } from '@isomera/interfaces'
+import { AuthService } from '../auth.service'
 
 @Injectable()
 export class Jwt2faStrategy extends PassportStrategy(Strategy, 'jwt-2fa') {
-  constructor(private readonly userService: UserService) {
+  constructor(private readonly authService: AuthService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: process.env.APP_SECRET
     })
   }
 
-  async validate(payload: LoginWith2FAPayload) {
-    const user = await this.userService.findOne({
-      where: { email: payload.email }
-    })
-
-    if (!user.isTwoFAEnabled) {
-      return user
-    }
-
-    if (payload.isTwoFactorAuthenticated) {
-      return {
-        ...user,
-        isTwoFactorAuthenticated: payload.isTwoFactorAuthenticated
-      }
-    }
+  async validate(payload: JwtPayload) {
+    return this.authService.verifyPayload(payload);
   }
 }

--- a/libs/interfaces/src/auth/jwtPayload.interface.ts
+++ b/libs/interfaces/src/auth/jwtPayload.interface.ts
@@ -1,4 +1,4 @@
-export interface JwtPayload {
+export interface JwtPayload extends LoginWith2FAPayload {
   sub: string
   iat: number
   exp: number
@@ -10,6 +10,6 @@ export interface LoginWithEmailPayload {
 
 export interface LoginWith2FAPayload {
   email: string
-  isTwoFactorAuthenticated: boolean
+  isTwoFactorAuthenticated?: boolean
   isTwoFactorAuthenticationEnabled: boolean
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)
- Specify if it's work in progress by adding label `work_in_progress`

Please ensure you read the Contributing Guide: https://github.com/cortip/isomera/blob/main/CONTRIBUTING.md
-->

### What does it do?

Instead of direct usage of UserService, it uses unified function `verifyPayload` of authService to validate JWT Payload. Also, unifies 2FA and non 2FA Authentication validation.

### Why is it needed?

Incorrect usage, as with verifyPayload using `payload.sub` it would only work for written test cases, and not when 2FA is turned off.

### How to test it?

Login with 2FA and without 2FA, and check whether token is validating things properly.

### Related issue(s)/PR(s)

#234 
